### PR TITLE
Username and password auth method added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_store
 target
 mac_sdk/MacOSX12.3.sdk
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,6 +1959,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2693,7 +2714,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "viax"
-version = "0.0.1-rc1"
+version = "0.0.2"
 dependencies = [
  "api",
  "clap",
@@ -2701,6 +2722,7 @@ dependencies = [
  "directories 6.0.0",
  "openssl",
  "query",
+ "rpassword",
  "viax-config",
  "viax-schema",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "viax"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 
 [dependencies]
@@ -11,6 +11,7 @@ viax-schema = { path = "schema" }
 query = { path = "query" }
 api = { path = "api" }
 viax-config = { path = "config" }
+rpassword = "7.4.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 openssl = { version = "0.10.68", features = ["vendored"] }

--- a/README.md
+++ b/README.md
@@ -42,12 +42,13 @@ auth_url = "https://auth.viax.demo.viax.io"
 api_url = "https://api.viax.demo.viax.io/graphql"
 [dev]
 client_id = "demo-client"
-client_secret = "a81c3b72-0c8f-4885-b888-9999fa123455"
+user = "viax-user"
 ```
 
 Specify your realm at the top of file, e.g. `realm = "viax"`. Then in square brackats it is env specific configuration, required:
 * client_id
-* client_secret  
+* client_secret 
+* user - in case of authentication via username/password, password will be asked on each command execution
 Optional, if not specified it is built from a pattern:
 * auth_url - pattern for a default one `https://auth.{realm}.{env}.viax.io`
 * api_url patter for a default url `https://api.{realm}.{env}.viax.io/graphql`

--- a/api/src/api.rs
+++ b/api/src/api.rs
@@ -9,11 +9,12 @@ pub fn deploy(
     cfg: &ViaxConfig,
     env_cfg: &ConfVal,
     env: &str,
+    password: &String,
     path: &PathBuf,
     operation: String,
 ) -> Response {
     let req_client = reqwest::blocking::Client::new();
-    let viax_api_token = acquire_token(env_cfg, &cfg.realm, env, &req_client);
+    let viax_api_token = acquire_token(env_cfg, &cfg.realm, env, password, &req_client);
     // let viax_api_token = std::env::var("VIAX_API_TOKEN").expect("Missing VIAX_API_TOKEN env var");
 
     let form = reqwest::blocking::multipart::Form::new()

--- a/api/src/int.rs
+++ b/api/src/int.rs
@@ -20,11 +20,12 @@ pub fn delete_int(
     env_cfg: &ConfVal,
     env: &str,
     name: &str,
+    password: &String,
 ) -> Result<(), Box<dyn Error>> {
     use cynic::http::ReqwestBlockingExt;
 
     let req_client = reqwest::blocking::Client::new();
-    let viax_api_token = acquire_token(env_cfg, &cfg.realm, env, &req_client);
+    let viax_api_token = acquire_token(env_cfg, &cfg.realm, env, password, &req_client);
 
     let int = get_int_with_token(cfg, env_cfg, env, &req_client, name, &viax_api_token).unwrap();
 
@@ -91,9 +92,10 @@ pub fn get_int(
     env_cfg: &ConfVal,
     env: &str,
     name: &str,
+    password: &String,
 ) -> Result<IntegrationDeployment, Box<dyn Error>> {
     let req_client = reqwest::blocking::Client::new();
-    let viax_api_token = acquire_token(env_cfg, &cfg.realm, env, &req_client);
+    let viax_api_token = acquire_token(env_cfg, &cfg.realm, env, password, &req_client);
 
     let int_result = get_int_with_token(cfg, env_cfg, env, &req_client, name, &viax_api_token);
     if let Ok(ref int) = int_result {
@@ -106,12 +108,14 @@ pub fn command_deploy_int(
     cfg: &ViaxConfig,
     env_cfg: &ConfVal,
     env: &str,
+    password: &String,
     path: &PathBuf,
 ) -> Result<(), Box<dyn Error>> {
     let response = deploy(
         cfg,
         env_cfg,
         env,
+        password,
         path,
         String::from(
             r#"{ "operationName": "upsertIntegrationDeployment", "query": "mutation upsertIntegrationDeployment($file: Upload!) { upsertIntegrationDeployment(input: { package: $file }) { uid name deployStatus latestDeploymentStartedAt enqueuedAt } }", "variables": { "file": null } }"#,

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -5,7 +5,9 @@ use std::collections::HashMap;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ConfVal {
     pub client_id: String,
-    pub client_secret: String,
+    pub client_secret: Option<String>,
+    pub user: Option<String>,
+    pub password: Option<String>,
     auth_url: Option<String>,
     api_url: Option<String>,
 }
@@ -53,7 +55,9 @@ impl ::std::default::Default for ViaxConfig {
     fn default() -> Self {
         let conf_val = ConfVal {
             client_id: "".into(),
-            client_secret: "".into(),
+            client_secret: Some("".to_string()),
+            user: Some("".to_string()),
+            password: Some("".to_string()),
             auth_url: Some("".to_string()),
             api_url: Some("".to_string()),
         };


### PR DESCRIPTION
Now it is possible to configure `<user_home>/.viax/config` to use username/password:
```
realm = "viax"
[default]
client_id = "demo-client"
client_secret = "a81c3b72-0c8f-4885-b888-9999fa123455"
auth_url = "https://auth.viax.demo.viax.io"
api_url = "https://api.viax.demo.viax.io/graphql"
[dev]
client_id = "demo-client"
user = "viax-user"
```
Password will be asked each time command executed.